### PR TITLE
Convenience features: Loader callback and Unicode database paths

### DIFF
--- a/src/sidplayfp/SidTune.cpp
+++ b/src/sidplayfp/SidTune.cpp
@@ -50,10 +50,15 @@ const char* defaultFileNameExt[] =
 const char** SidTune::fileNameExtensions = defaultFileNameExt;
 
 SidTune::SidTune(const char* fileName, const char **fileNameExt, bool separatorIsSlash) :
+    SidTune(fileName, fileNameExt, separatorIsSlash, nullptr)
+{
+}
+
+SidTune::SidTune(const char* fileName, const char **fileNameExt, bool separatorIsSlash, LoaderFunc loader) :
     tune(nullptr)
 {
     setFileNameExtensions(fileNameExt);
-    load(fileName, separatorIsSlash);
+    load(fileName, separatorIsSlash, loader);
 }
 
 SidTune::SidTune(const uint_least8_t* oneFileFormatSidtune, uint_least32_t sidtuneLength) :
@@ -74,10 +79,15 @@ void SidTune::setFileNameExtensions(const char **fileNameExt)
 
 void SidTune::load(const char* fileName, bool separatorIsSlash)
 {
+    load(fileName, separatorIsSlash, nullptr);
+}
+
+void SidTune::load(const char* fileName, bool separatorIsSlash, LoaderFunc loader)
+{
     try
     {
         delete tune;
-        tune = SidTuneBase::load(fileName, fileNameExtensions, separatorIsSlash);
+        tune = SidTuneBase::load(fileName, fileNameExtensions, separatorIsSlash, loader);
         m_status = true;
         m_statusString = MSG_NO_ERRORS;
     }

--- a/src/sidplayfp/SidTune.h
+++ b/src/sidplayfp/SidTune.h
@@ -24,6 +24,7 @@
 #define SIDTUNE_H
 
 #include <stdint.h>
+#include <vector>
 
 #include "sidplayfp/siddefs.h"
 
@@ -56,6 +57,8 @@ private:  // -------------------------------------------------------------
 
 public:  // ----------------------------------------------------------------
 
+    typedef void (*LoaderFunc)(const char* fileName, std::vector<uint8_t>& bufferRef);
+
     /**
      * Load a sidtune from a file.
      *
@@ -74,6 +77,21 @@ public:  // ----------------------------------------------------------------
      */
     SidTune(const char* fileName, const char **fileNameExt = 0,
             bool separatorIsSlash = false);
+
+    /**
+     * Load a sidtune from a file, using a file access callback.
+     *
+     * This function does the same as the above, except that it
+     * accepts a callback function, which will be used to read
+     * all files it accesses.
+     *
+     * @param fileName
+     * @param fileNameExt
+     * @param separatorIsSlash
+     * @param loader
+     */
+    SidTune(const char* fileName, const char **fileNameExt = 0,
+            bool separatorIsSlash = false, LoaderFunc loader = nullptr);
 
     /**
      * Load a single-file sidtune from a memory buffer.
@@ -103,6 +121,16 @@ public:  // ----------------------------------------------------------------
      * @param separatorIsSlash
      */
     void load(const char* fileName, bool separatorIsSlash = false);
+
+    /**
+     * Load a sidtune into an existing object from a file,
+     * using a file access callback.
+     *
+     * @param fileName
+     * @param separatorIsSlash
+     * @param loader
+     */
+    void load(const char* fileName, bool separatorIsSlash = false, LoaderFunc loader = nullptr);
 
     /**
      * Load a sidtune into an existing object from a buffer.

--- a/src/sidtune/SidTuneBase.h
+++ b/src/sidtune/SidTuneBase.h
@@ -73,6 +73,8 @@ protected:
 public:  // ----------------------------------------------------------------
     virtual ~SidTuneBase() {}
 
+    typedef void (*LoaderFunc)(const char* fileName, buffer_t& bufferRef);
+
     /**
      * Load a sidtune from a file.
      *
@@ -90,6 +92,22 @@ public:  // ----------------------------------------------------------------
      * @throw loadError
      */
     static SidTuneBase* load(const char* fileName, const char **fileNameExt, bool separatorIsSlash);
+
+    /**
+     * Load a sidtune from a file, using a file access callback.
+     *
+     * Uses the same call methodology as the above function, only
+     * a callback is supplied, which will be used to read every
+     * file this function accesses.
+     *
+     * @param fileName
+     * @param fileNameExt
+     * @param separatorIsSlash
+     * @param loader
+     * @return the sid tune
+     * @throw loadError
+     */
+    static SidTuneBase* load(const char* fileName, const char **fileNameExt, bool separatorIsSlash, LoaderFunc loader);
 
     /**
      * Load a single-file sidtune from a memory buffer.
@@ -236,6 +254,7 @@ private:  // ---------------------------------------------------------------
     static SidTuneBase* getFromStdIn();
 #endif
     static SidTuneBase* getFromFiles(const char* name, const char **fileNameExtensions, bool separatorIsSlash);
+    static SidTuneBase* getFromFiles(const char* name, const char **fileNameExtensions, bool separatorIsSlash, LoaderFunc loader);
 
     /**
      * Try to retrieve single-file sidtune from specified buffer.

--- a/src/utils/SidDatabase.cpp
+++ b/src/utils/SidDatabase.cpp
@@ -110,6 +110,23 @@ bool SidDatabase::open(const char *filename)
     return true;
 }
 
+#ifdef _WIN32
+bool SidDatabase::open(const wchar_t* filename)
+{
+    delete m_parser;
+    m_parser = new libsidplayfp::iniParser();
+
+    if (!m_parser->open(filename))
+    {
+        close();
+        errorString = ERR_UNABLE_TO_LOAD_DATABASE;
+        return false;
+    }
+
+    return true;
+}
+#endif
+
 void SidDatabase::close()
 {
     delete m_parser;

--- a/src/utils/SidDatabase.h
+++ b/src/utils/SidDatabase.h
@@ -56,6 +56,9 @@ public:
      * @return false in case of errors, true otherwise.
      */
     bool open(const char *filename);
+#ifdef _WIN32
+    bool open(const wchar_t* filename);
+#endif
 
     /**
      * Close the songlength DataBase.

--- a/src/utils/iniParser.cpp
+++ b/src/utils/iniParser.cpp
@@ -57,6 +57,20 @@ bool iniParser::open(const char *fName)
 {
     std::ifstream iniFile(fName);
 
+    return open_internal(iniFile);
+}
+
+#ifdef _WIN32
+bool iniParser::open(const wchar_t *fName)
+{
+    std::ifstream iniFile(fName);
+
+    return open_internal(iniFile);
+}
+#endif
+
+bool iniParser::open_internal(std::ifstream & iniFile)
+{
     if (iniFile.fail())
     {
         return false;

--- a/src/utils/iniParser.h
+++ b/src/utils/iniParser.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <map>
 #include <utility>
+#include <fstream>
 
 namespace libsidplayfp
 {
@@ -42,8 +43,13 @@ private:
 
     keys_t::value_type parseKey(const std::string &buffer);
 
+    bool open_internal(std::ifstream& iniFile);
+
 public:
     bool open(const char *fName);
+#ifdef _WIN32
+    bool open(const wchar_t* fName);
+#endif
     void close();
 
     bool setSection(const char *section);


### PR DESCRIPTION
Added two convenience features needed by my foobar2000 plugin:

- Loader callback for the file-based song loader, so multi-song tunes can be loaded using custom file loaders, including from archives or whatever. Fully compatible with existing code with a recompile, but not binary compatible since there's a new optional function.
- Unicode file path support for the database and INI loader, only enabled on Windows, where it's actually needed.