### PR TITLE
Add mutex locks around cache object usage

### DIFF
--- a/src/builders/residfp-builder/residfp/WaveformCalculator.cpp
+++ b/src/builders/residfp-builder/residfp/WaveformCalculator.cpp
@@ -172,6 +172,8 @@ short calculateCombinedWaveform(const CombinedWaveformConfig& config, int wavefo
 
 matrix_t* WaveformCalculator::buildTable(ChipModel model)
 {
+    std::lock_guard<std::mutex> lock(CACHE_Lock);
+
     const CombinedWaveformConfig* cfgArray = config[model == MOS6581 ? 0 : 1];
 
     cw_cache_t::iterator lb = CACHE.lower_bound(cfgArray);

--- a/src/builders/residfp-builder/residfp/WaveformCalculator.h
+++ b/src/builders/residfp-builder/residfp/WaveformCalculator.h
@@ -23,6 +23,7 @@
 #define WAVEFORMCALCULATOR_h
 
 #include <map>
+#include <mutex>
 
 #include "array.h"
 #include "sidcxx11.h"
@@ -105,6 +106,7 @@ private:
 
 private:
     cw_cache_t CACHE;
+    std::mutex CACHE_Lock;
 
     WaveformCalculator() DEFAULT;
 

--- a/src/builders/residfp-builder/residfp/resample/SincResampler.cpp
+++ b/src/builders/residfp-builder/residfp/resample/SincResampler.cpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <iostream>
 #include <sstream>
+#include <mutex>
 
 #include "siddefs-fp.h"
 
@@ -49,6 +50,7 @@ typedef std::map<std::string, matrix_t> fir_cache_t;
 
 /// Cache for the expensive FIR table computation results.
 fir_cache_t FIR_CACHE;
+std::mutex CACHE_Lock;
 
 /// Maximum error acceptable in I0 is 1e-6, or ~96 dB.
 const double I0E = 1e-6;
@@ -312,6 +314,9 @@ SincResampler::SincResampler(double clockFrequency, double samplingFrequency, do
     std::ostringstream o;
     o << firN << "," << firRES << "," << cyclesPerSampleD;
     const std::string firKey = o.str();
+
+    std::lock_guard<std::mutex> lock(CACHE_Lock);
+
     fir_cache_t::iterator lb = FIR_CACHE.lower_bound(firKey);
 
     // The FIR computation is expensive and we set sampling parameters often, but


### PR DESCRIPTION
Cache objects should be synchronized across threads, or else
they may be used improperly when the library is being used
from multiple threads simultaneously.