### PR TITLE
Reworked noise shift register and writeback logic

### DIFF
--- a/src/builders/residfp-builder/residfp/WaveformGenerator.cpp
+++ b/src/builders/residfp-builder/residfp/WaveformGenerator.cpp
@@ -114,6 +114,9 @@ inline bool do_writeback(unsigned int waveform_old, unsigned int waveform_new, b
     // no writeback without combined waveforms
     if (waveform_new <= 8)
         return false;
+    if (waveform_old <= 8)
+        return false; // fixes SID/noisewriteback/noise_writeback_test2-{old,new}
+
     // What's happening here?
     if (is6581 &&
             ((((waveform_old & 0x3) == 0x1) && ((waveform_new & 0x3) == 0x2))
@@ -128,7 +131,7 @@ inline bool do_writeback(unsigned int waveform_old, unsigned int waveform_new, b
         // noise_writeback_check_E_to_9_old
         return false;
     }
-    if ((waveform_old == 0xc) && (waveform_new == 0xA))
+    if (waveform_old == 0xc)
     {
         // fixes
         // noise_writeback_check_C_to_A_new

--- a/src/builders/residfp-builder/residfp/WaveformGenerator.cpp
+++ b/src/builders/residfp-builder/residfp/WaveformGenerator.cpp
@@ -162,6 +162,11 @@ inline unsigned int get_noise_writeback(unsigned int waveform_output)
     ((waveform_output & (1u <<  4)) << 18);   // Bit  4 -> bit  0
 }
 
+/*
+ * Perform the actual shifting, moving the latched value into following bits.
+ * The XORing for bit0 is done in this cycle using the test bit latched during
+ * the previous phi2 cycle.
+ */
 void WaveformGenerator::shift_phase2(unsigned int waveform_old, unsigned int waveform_new)
 {
     if (do_writeback(waveform_old, waveform_new, is6581))
@@ -331,7 +336,6 @@ void WaveformGenerator::writeCONTROL_REG(unsigned char control)
         {
             // When the test bit is falling, the second phase of the shift is
             // completed by enabling SRAM write.
-            //shift_pipeline = 1;
             shift_phase2(waveform_prev, waveform);
         }
     }

--- a/src/builders/residfp-builder/residfp/WaveformGenerator.h
+++ b/src/builders/residfp-builder/residfp/WaveformGenerator.h
@@ -152,7 +152,7 @@ private:
     bool is6581; //-V730_NOINIT this is initialized in the SID constructor
 
 private:
-    void shift_phase2();
+    void shift_phase2(unsigned int waveform_old, unsigned int waveform_new);
 
     void write_shift_register();
 
@@ -351,7 +351,7 @@ void WaveformGenerator::clock()
 #ifdef TRACE
                 std::cout << "shift phase 2" << std::endl;
 #endif
-                shift_phase2();
+                shift_phase2(waveform, waveform);
                 break;
             case 1:
 #ifdef TRACE

--- a/src/builders/residfp-builder/residfp/WaveformGenerator.h
+++ b/src/builders/residfp-builder/residfp/WaveformGenerator.h
@@ -28,9 +28,12 @@
 
 #include "sidcxx11.h"
 
-#include <iostream>
-
+// print SR debugging info
 //#define TRACE 1
+
+#ifdef TRACE
+#  include <iostream>
+#endif
 
 namespace reSIDfp
 {

--- a/tests/TestWaveformGenerator.cpp
+++ b/tests/TestWaveformGenerator.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- *  Copyright (C) 2014-2022 Leandro Nini
+ *  Copyright (C) 2014-2023 Leandro Nini
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -52,7 +52,11 @@ TEST(TestClockShiftRegister)
     generator.reset();
 
     generator.shift_register = 0x35555e;
-    generator.clock_shift_register(0);
+    // shift phase 1
+    generator.test_or_reset = false;
+    generator.shift_latch = generator.shift_register;
+    // shift phase 2
+    generator.shift_phase2(0, 0);
 
     CHECK_EQUAL(0x9e0, generator.noise_output);
 }


### PR DESCRIPTION
Fixes:
* SID/wb_testsuite/noise_writeback_check_8_to_C_old
* SID/wb_testsuite/noise_writeback_check_9_to_C_old
* SID/wb_testsuite/noise_writeback_check_A_to_C_old
* SID/wb_testsuite/noise_writeback_check_C_to_C_old

Breaks:
* SID/wf12nsr/wf12nsr