### PR TITLE
Fix SSE2 version of convolve()

### DIFF
--- a/src/builders/residfp-builder/residfp/resample/SincResampler.cpp
+++ b/src/builders/residfp-builder/residfp/resample/SincResampler.cpp
@@ -127,7 +127,7 @@ int convolve(const short* a, const short* b, int bLength)
         for (int i = 0; i < n; i++)
         {
             const __m128i tmp = _mm_madd_epi16(*(__m128i*)a, *(__m128i*)b);
-            acc = _mm_add_epi16(acc, tmp);
+            acc = _mm_add_epi32(acc, tmp);
             a += 8;
             b += 8;
         }


### PR DESCRIPTION
_mm_madd_epi16 returns an array of 4 int32_t, so must use _mm_add_epi32() to accumulate them correctly. The cross-addition performed later is correct.

Fixes #105