### PR TITLE
Fix autoconf logic for tests option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,14 +252,17 @@ AC_ARG_ENABLE([tests],
   [AS_HELP_STRING([--enable-tests],
     [enable unit tests [default=no]]
   )],
-  [[echo Enabling unit tests]
-    PKG_CHECK_MODULES(UNITTEST, [UnitTest++])
-    [am_unittest=true]
-  ],
-  [am_unittest=false]
+  [],
+  [enable_tests=no]
 )
 
-AM_CONDITIONAL([ENABLE_TEST], [test x$am_unittest = xtrue])
+AS_IF([test "x$enable_tests" != "xno"],
+  [[echo Enabling unit tests]
+    PKG_CHECK_MODULES(UNITTEST, [UnitTest++])
+  ]
+)
+
+AM_CONDITIONAL([ENABLE_TEST], [test x$enable_tests = xyes])
 
 
 AC_ARG_WITH([gcrypt], AS_HELP_STRING([--with-gcrypt], [Build with the gcrypt library]))


### PR DESCRIPTION
Currently, the [`action-if-given` part of the `AC_ARG_ENABLE` call](https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Package-Options.html) for the unit tests option is used as if it meant `action-if-enabled`. This means that passing `--enable-tests=no` or `--disable-tests` will *enable* the tests, and not passing the option to use the default value is the only way to disable them.

Rework the logic into a separate `AS_IF` check of the value, just like how the other options are doing it, to fix this.