### PR TITLE
Optimize member ptr funcs usage

### DIFF
--- a/src/EventCallback.h
+++ b/src/EventCallback.h
@@ -52,6 +52,22 @@ public:
     {}
 };
 
+template< class This, void(This::*Callback)() >
+class FastEventCallback final : public Event
+{
+private:
+    This &m_this;
+
+private:
+    void event() override { (m_this.*Callback)(); }
+
+public:
+    FastEventCallback(const char* const name, This &object) :
+       Event(name),
+       m_this(object)
+    {}
+};
+
 }
 
 #endif // EVENTCALLBACK_H

--- a/src/c64/CPU/mos6510.cpp
+++ b/src/c64/CPU/mos6510.cpp
@@ -1474,9 +1474,9 @@ MOS6510::MOS6510(EventScheduler &scheduler) :
 #ifdef DEBUG
     m_fdbg(stdout),
 #endif
-    m_nosteal("CPU-nosteal", *this, &MOS6510::eventWithoutSteals),
-    m_steal("CPU-steal", *this, &MOS6510::eventWithSteals),
-    clearInt("Remove IRQ", *this, &MOS6510::removeIRQ)
+    m_nosteal("CPU-nosteal", *this),
+    m_steal("CPU-steal", *this),
+    clearInt("Remove IRQ", *this)
 {
     buildInstructionTable();
 

--- a/src/c64/CPU/mos6510.cpp
+++ b/src/c64/CPU/mos6510.cpp
@@ -51,13 +51,19 @@ const int interruptDelay = 2;
 
 //-------------------------------------------------------------------------//
 
+template<void(MOS6510::*Func)()>
+void StaticFuncWrapper(MOS6510& self)
+{
+    (self.*Func)();
+}
+
 /**
  * When AEC signal is high, no stealing is possible.
  */
 void MOS6510::eventWithoutSteals()
 {
     const ProcessorCycle &instr = instrTable[cycleCount++];
-    (this->*(instr.func)) ();
+    (instr.func)(*this);
     eventScheduler.schedule(m_nosteal, 1);
 }
 
@@ -69,7 +75,7 @@ void MOS6510::eventWithSteals()
     if (instrTable[cycleCount].nosteal)
     {
         const ProcessorCycle &instr = instrTable[cycleCount++];
-        (this->*(instr.func)) ();
+        (instr.func)(*this);
         eventScheduler.schedule(m_steal, 1);
     }
     else
@@ -1523,7 +1529,7 @@ void MOS6510::buildInstructionTable()
         case PHPn: case PLAn: case PLPn: case ROLn: case RORn:
         case SECn: case SEDn: case SEIn: case TAXn:  case TAYn:
         case TSXn: case TXAn: case TXSn: case TYAn:
-            instrTable[buildCycle++].func = &MOS6510::throwAwayFetch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::throwAwayFetch>;
             break;
 
         // Immediate and Relative Addressing Mode Handler
@@ -1532,7 +1538,7 @@ void MOS6510::buildInstructionTable()
         case BRKn: case BVCr:  case BVSr:  case CMPb: case CPXb: case CPYb:
         case EORb: case LDAb:  case LDXb:  case LDYb: case LXAb: case NOPb_:
         case ORAb: case SBCb_: case SBXb:  case RTIn: case RTSn:
-            instrTable[buildCycle++].func = &MOS6510::FetchDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchDataByte>;
             break;
 
         // Zero Page Addressing Mode Handler - Read & RMW
@@ -1544,7 +1550,7 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case SAXz: case STAz: case STXz: case STYz:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddr>;
             break;
 
         // Zero Page with X Offset Addressing Mode Handler
@@ -1558,9 +1564,9 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case STAzx: case STYzx:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddrX;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddrX>;
             // operates on 0 page in read mode. Truly side-effect free.
-            instrTable[buildCycle++].func = &MOS6510::WasteCycle;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::WasteCycle>;
             break;
 
         // Zero Page with Y Offset Addressing Mode Handler
@@ -1568,9 +1574,9 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case STXzy: case SAXzy:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddrY;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddrY>;
             // operates on 0 page in read mode. Truly side-effect free.
-            instrTable[buildCycle++].func = &MOS6510::WasteCycle;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::WasteCycle>;
             break;
 
         // Absolute Addressing Mode Handler
@@ -1582,23 +1588,23 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case JMPw: case SAXa: case STAa: case STXa: case STYa:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighAddr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighAddr>;
             break;
 
         case JSRw:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddr>;
             break;
 
         // Absolute With X Offset Addressing Mode Handler (Read)
         case ADCax: case ANDax:  case CMPax: case EORax: case LDAax:
         case LDYax: case NOPax_: case ORAax: case SBCax:
             access = READ;
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighAddrX2;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighAddrX2>;
             // this cycle is skipped if the address is already correct.
             // otherwise, it will be read and ignored.
-            instrTable[buildCycle++].func = &MOS6510::throwAwayRead;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::throwAwayRead>;
             break;
 
         // Absolute X (RMW; no page crossing handled, always reads before writing)
@@ -1608,9 +1614,9 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case SHYax: case STAax:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighAddrX;
-            instrTable[buildCycle++].func = &MOS6510::throwAwayRead;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighAddrX>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::throwAwayRead>;
             break;
 
         // Absolute With Y Offset Addresing Mode Handler (Read)
@@ -1618,9 +1624,9 @@ void MOS6510::buildInstructionTable()
         case LAXay: case LDAay: case LDXay: case ORAay: case SBCay:
             access = READ;
             // fallthrough
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighAddrY2;
-            instrTable[buildCycle++].func = &MOS6510::throwAwayRead;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighAddrY2>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::throwAwayRead>;
             break;
 
         // Absolute Y (No page crossing handled)
@@ -1629,17 +1635,17 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case SHAay: case SHSay: case SHXay: case STAay:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighAddrY;
-            instrTable[buildCycle++].func = &MOS6510::throwAwayRead;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighAddrY>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::throwAwayRead>;
             break;
 
         // Absolute Indirect Addressing Mode Handler
         case JMPi:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowPointer;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighPointer;
-            instrTable[buildCycle++].func = &MOS6510::FetchLowEffAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighEffAddr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowPointer>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighPointer>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowEffAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighEffAddr>;
             break;
 
         // Indexed with X Preinc Addressing Mode Handler
@@ -1649,20 +1655,20 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case SAXix: case STAix:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowPointer;
-            instrTable[buildCycle++].func = &MOS6510::FetchLowPointerX;
-            instrTable[buildCycle++].func = &MOS6510::FetchLowEffAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighEffAddr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowPointer>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowPointerX>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowEffAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighEffAddr>;
             break;
 
         // Indexed with Y Postinc Addressing Mode Handler (Read)
         case ADCiy: case ANDiy: case CMPiy: case EORiy: case LAXiy:
         case LDAiy: case ORAiy: case SBCiy:
             access = READ;
-            instrTable[buildCycle++].func = &MOS6510::FetchLowPointer;
-            instrTable[buildCycle++].func = &MOS6510::FetchLowEffAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighEffAddrY2;
-            instrTable[buildCycle++].func = &MOS6510::throwAwayRead;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowPointer>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowEffAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighEffAddrY2>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::throwAwayRead>;
             break;
 
         // Indexed Y (No page crossing handled)
@@ -1671,10 +1677,10 @@ void MOS6510::buildInstructionTable()
             access = READ;
             // fallthrough
         case SHAiy: case STAiy:
-            instrTable[buildCycle++].func = &MOS6510::FetchLowPointer;
-            instrTable[buildCycle++].func = &MOS6510::FetchLowEffAddr;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighEffAddrY;
-            instrTable[buildCycle++].func = &MOS6510::throwAwayRead;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowPointer>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchLowEffAddr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighEffAddrY>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::throwAwayRead>;
             break;
 
         default:
@@ -1684,7 +1690,7 @@ void MOS6510::buildInstructionTable()
 
         if (access == READ)
         {
-            instrTable[buildCycle++].func = &MOS6510::FetchEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchEffAddrDataByte>;
         }
 
         //---------------------------------------------------------------------------------------
@@ -1694,152 +1700,152 @@ void MOS6510::buildInstructionTable()
         {
         case ADCz:  case ADCzx: case ADCa: case ADCax: case ADCay: case ADCix:
         case ADCiy: case ADCb:
-            instrTable[buildCycle++].func = &MOS6510::adc_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::adc_instr>;
             break;
 
         case ANCb_:
-            instrTable[buildCycle++].func = &MOS6510::anc_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::anc_instr>;
             break;
 
         case ANDz:  case ANDzx: case ANDa: case ANDax: case ANDay: case ANDix:
         case ANDiy: case ANDb:
-            instrTable[buildCycle++].func = &MOS6510::and_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::and_instr>;
             break;
 
         case ANEb: // Also known as XAA
-            instrTable[buildCycle++].func = &MOS6510::ane_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::ane_instr>;
             break;
 
         case ARRb:
-            instrTable[buildCycle++].func = &MOS6510::arr_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::arr_instr>;
             break;
 
         case ASLn:
-            instrTable[buildCycle++].func = &MOS6510::asla_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::asla_instr>;
             break;
 
         case ASLz: case ASLzx: case ASLa: case ASLax:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::asl_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::asl_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case ASRb: // Also known as ALR
-            instrTable[buildCycle++].func = &MOS6510::alr_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::alr_instr>;
             break;
 
         case BCCr:
-            instrTable[buildCycle++].func = &MOS6510::bcc_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bcc_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case BCSr:
-            instrTable[buildCycle++].func = &MOS6510::bcs_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bcs_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case BEQr:
-            instrTable[buildCycle++].func = &MOS6510::beq_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::beq_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case BITz: case BITa:
-            instrTable[buildCycle++].func = &MOS6510::bit_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bit_instr>;
             break;
 
         case BMIr:
-            instrTable[buildCycle++].func = &MOS6510::bmi_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bmi_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case BNEr:
-            instrTable[buildCycle++].func = &MOS6510::bne_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bne_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case BPLr:
-            instrTable[buildCycle++].func = &MOS6510::bpl_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bpl_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case BRKn:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PushHighPC;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PushHighPC>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::brkPushLowPC;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::brkPushLowPC>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PushSR;
-            instrTable[buildCycle++].func = &MOS6510::IRQLoRequest;
-            instrTable[buildCycle++].func = &MOS6510::IRQHiRequest;
-            instrTable[buildCycle++].func = &MOS6510::fetchNextOpcode;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PushSR>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::IRQLoRequest>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::IRQHiRequest>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fetchNextOpcode>;
             break;
 
         case BVCr:
-            instrTable[buildCycle++].func = &MOS6510::bvc_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bvc_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case BVSr:
-            instrTable[buildCycle++].func = &MOS6510::bvs_instr;
-            instrTable[buildCycle++].func = &MOS6510::fix_branch;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::bvs_instr>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::fix_branch>;
             break;
 
         case CLCn:
-            instrTable[buildCycle++].func = &MOS6510::clc_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::clc_instr>;
             break;
 
         case CLDn:
-            instrTable[buildCycle++].func = &MOS6510::cld_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::cld_instr>;
             break;
 
         case CLIn:
-            instrTable[buildCycle++].func = &MOS6510::cli_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::cli_instr>;
             break;
 
         case CLVn:
-            instrTable[buildCycle++].func = &MOS6510::clv_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::clv_instr>;
             break;
 
         case CMPz:  case CMPzx: case CMPa: case CMPax: case CMPay: case CMPix:
         case CMPiy: case CMPb:
-            instrTable[buildCycle++].func = &MOS6510::cmp_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::cmp_instr>;
             break;
 
         case CPXz: case CPXa: case CPXb:
-            instrTable[buildCycle++].func = &MOS6510::cpx_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::cpx_instr>;
             break;
 
         case CPYz: case CPYa: case CPYb:
-            instrTable[buildCycle++].func = &MOS6510::cpy_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::cpy_instr>;
             break;
 
         case DCPz: case DCPzx: case DCPa: case DCPax: case DCPay: case DCPix:
         case DCPiy: // Also known as DCM
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::dcm_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::dcm_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case DECz: case DECzx: case DECa: case DECax:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::dec_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::dec_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case DEXn:
-            instrTable[buildCycle++].func = &MOS6510::dex_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::dex_instr>;
             break;
 
         case DEYn:
-            instrTable[buildCycle++].func = &MOS6510::dey_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::dey_instr>;
             break;
 
         case EORz:  case EORzx: case EORa: case EORax: case EORay: case EORix:
         case EORiy: case EORb:
-            instrTable[buildCycle++].func = &MOS6510::eor_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::eor_instr>;
             break;
 #if 0
         // HLT, also known as JAM
@@ -1847,74 +1853,74 @@ void MOS6510::buildInstructionTable()
         case 0x62: case 0x72: case 0x92: case 0xb2: case 0xd2: case 0xf2:
         case 0x02: case 0x12: case 0x22: case 0x32: case 0x42: case 0x52:
         case 0x62: case 0x72: case 0x92: case 0xb2: case 0xd2: case 0xf2:
-            instrTable[buildCycle++].func = hlt_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<hlt_instr>;
             break;
 #endif
         case INCz: case INCzx: case INCa: case INCax:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::inc_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::inc_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case INXn:
-            instrTable[buildCycle++].func = &MOS6510::inx_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::inx_instr>;
             break;
 
         case INYn:
-            instrTable[buildCycle++].func = &MOS6510::iny_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::iny_instr>;
             break;
 
         case ISBz: case ISBzx: case ISBa: case ISBax: case ISBay: case ISBix:
         case ISBiy: // Also known as INS
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::ins_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::ins_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case JSRw:
-            instrTable[buildCycle++].func = &MOS6510::WasteCycle;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::WasteCycle>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PushHighPC;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PushHighPC>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PushLowPC;
-            instrTable[buildCycle++].func = &MOS6510::FetchHighAddr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PushLowPC>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::FetchHighAddr>;
             // fallthrough
         case JMPw: case JMPi:
-            instrTable[buildCycle++].func = &MOS6510::jmp_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::jmp_instr>;
             break;
 
         case LASay:
-            instrTable[buildCycle++].func = &MOS6510::las_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::las_instr>;
             break;
 
         case LAXz: case LAXzy: case LAXa: case LAXay: case LAXix: case LAXiy:
-            instrTable[buildCycle++].func = &MOS6510::lax_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::lax_instr>;
             break;
 
         case LDAz:  case LDAzx: case LDAa: case LDAax: case LDAay: case LDAix:
         case LDAiy: case LDAb:
-            instrTable[buildCycle++].func = &MOS6510::lda_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::lda_instr>;
             break;
 
         case LDXz: case LDXzy: case LDXa: case LDXay: case LDXb:
-            instrTable[buildCycle++].func = &MOS6510::ldx_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::ldx_instr>;
             break;
 
         case LDYz: case LDYzx: case LDYa: case LDYax: case LDYb:
-            instrTable[buildCycle++].func = &MOS6510::ldy_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::ldy_instr>;
             break;
 
         case LSRn:
-            instrTable[buildCycle++].func = &MOS6510::lsra_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::lsra_instr>;
             break;
 
         case LSRz: case LSRzx: case LSRa: case LSRax:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::lsr_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::lsr_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case NOPn_: case NOPb_:
@@ -1924,195 +1930,195 @@ void MOS6510::buildInstructionTable()
             break;
 
         case LXAb: // Also known as OAL
-            instrTable[buildCycle++].func = &MOS6510::oal_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::oal_instr>;
             break;
 
         case ORAz:  case ORAzx: case ORAa: case ORAax: case ORAay: case ORAix:
         case ORAiy: case ORAb:
-            instrTable[buildCycle++].func = &MOS6510::ora_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::ora_instr>;
             break;
 
         case PHAn:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::pha_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::pha_instr>;
             break;
 
         case PHPn:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PushSR;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PushSR>;
             break;
 
         case PLAn:
             // should read the value at current stack register.
             // Truly side-effect free.
-            instrTable[buildCycle++].func = &MOS6510::WasteCycle;
-            instrTable[buildCycle++].func = &MOS6510::pla_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::WasteCycle>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::pla_instr>;
             break;
 
         case PLPn:
             // should read the value at current stack register.
             // Truly side-effect free.
-            instrTable[buildCycle++].func = &MOS6510::WasteCycle;
-            instrTable[buildCycle++].func = &MOS6510::PopSR;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::WasteCycle>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PopSR>;
             break;
 
         case RLAz: case RLAzx: case RLAix: case RLAa: case RLAax: case RLAay:
         case RLAiy:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::rla_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::rla_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case ROLn:
-            instrTable[buildCycle++].func = &MOS6510::rola_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::rola_instr>;
             break;
 
         case ROLz: case ROLzx: case ROLa: case ROLax:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::rol_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::rol_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case RORn:
-            instrTable[buildCycle++].func = &MOS6510::rora_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::rora_instr>;
             break;
 
         case RORz: case RORzx: case RORa: case RORax:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::ror_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::ror_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case RRAa: case RRAax: case RRAay: case RRAz: case RRAzx: case RRAix:
         case RRAiy:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::rra_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::rra_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case RTIn:
             // should read the value at current stack register.
             // Truly side-effect free.
-            instrTable[buildCycle++].func = &MOS6510::WasteCycle;
-            instrTable[buildCycle++].func = &MOS6510::PopSR;
-            instrTable[buildCycle++].func = &MOS6510::PopLowPC;
-            instrTable[buildCycle++].func = &MOS6510::PopHighPC;
-            instrTable[buildCycle++].func = &MOS6510::rti_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::WasteCycle>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PopSR>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PopLowPC>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PopHighPC>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::rti_instr>;
             break;
 
         case RTSn:
             // should read the value at current stack register.
             // Truly side-effect free.
-            instrTable[buildCycle++].func = &MOS6510::WasteCycle;
-            instrTable[buildCycle++].func = &MOS6510::PopLowPC;
-            instrTable[buildCycle++].func = &MOS6510::PopHighPC;
-            instrTable[buildCycle++].func = &MOS6510::rts_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::WasteCycle>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PopLowPC>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PopHighPC>;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::rts_instr>;
             break;
 
         case SAXz: case SAXzy: case SAXa: case SAXix: // Also known as AXS
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::axs_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::axs_instr>;
             break;
 
         case SBCz:  case SBCzx: case SBCa: case SBCax: case SBCay: case SBCix:
         case SBCiy: case SBCb_:
-            instrTable[buildCycle++].func = &MOS6510::sbc_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::sbc_instr>;
             break;
 
         case SBXb:
-            instrTable[buildCycle++].func = &MOS6510::sbx_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::sbx_instr>;
             break;
 
         case SECn:
-            instrTable[buildCycle++].func = &MOS6510::sec_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::sec_instr>;
             break;
 
         case SEDn:
-            instrTable[buildCycle++].func = &MOS6510::sed_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::sed_instr>;
             break;
 
         case SEIn:
-            instrTable[buildCycle++].func = &MOS6510::sei_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::sei_instr>;
             break;
 
         case SHAay: case SHAiy: // Also known as AXA
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::axa_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::axa_instr>;
             break;
 
         case SHSay: // Also known as TAS
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::shs_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::shs_instr>;
             break;
 
         case SHXay: // Also known as XAS
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::xas_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::xas_instr>;
             break;
 
         case SHYax: // Also known as SAY
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::say_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::say_instr>;
             break;
 
         case SLOz: case SLOzx: case SLOa: case SLOax: case SLOay: case SLOix:
         case SLOiy: // Also known as ASO
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::aso_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::aso_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case SREz: case SREzx: case SREa: case SREax: case SREay: case SREix:
         case SREiy: // Also known as LSE
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::lse_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::lse_instr>;
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::PutEffAddrDataByte;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::PutEffAddrDataByte>;
             break;
 
         case STAz: case STAzx: case STAa: case STAax: case STAay: case STAix:
         case STAiy:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::sta_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::sta_instr>;
             break;
 
         case STXz: case STXzy: case STXa:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::stx_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::stx_instr>;
             break;
 
         case STYz: case STYzx: case STYa:
             instrTable[buildCycle].nosteal = true;
-            instrTable[buildCycle++].func = &MOS6510::sty_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::sty_instr>;
             break;
 
         case TAXn:
-            instrTable[buildCycle++].func = &MOS6510::tax_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::tax_instr>;
             break;
 
         case TAYn:
-            instrTable[buildCycle++].func = &MOS6510::tay_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::tay_instr>;
             break;
 
         case TSXn:
-            instrTable[buildCycle++].func = &MOS6510::tsx_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::tsx_instr>;
             break;
 
         case TXAn:
-            instrTable[buildCycle++].func = &MOS6510::txa_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::txa_instr>;
             break;
 
         case TXSn:
-            instrTable[buildCycle++].func = &MOS6510::txs_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::txs_instr>;
             break;
 
         case TYAn:
-            instrTable[buildCycle++].func = &MOS6510::tya_instr;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::tya_instr>;
             break;
 
         default:
@@ -2125,11 +2131,11 @@ void MOS6510::buildInstructionTable()
         // CPU state machine locks up and will never recover.
         if (!(legalMode && legalInstr))
         {
-            instrTable[buildCycle++].func = &MOS6510::invalidOpcode;
+            instrTable[buildCycle++].func = &StaticFuncWrapper<&MOS6510::invalidOpcode>;
         }
 
         // check for IRQ triggers or fetch next opcode...
-        instrTable[buildCycle].func = &MOS6510::interruptsAndNextOpcode;
+        instrTable[buildCycle].func = &StaticFuncWrapper<&MOS6510::interruptsAndNextOpcode>;
 
 #if DEBUG > 1
         printf("Done [%d Cycles]\n", buildCycle - (i << 3));

--- a/src/c64/CPU/mos6510.h
+++ b/src/c64/CPU/mos6510.h
@@ -150,17 +150,17 @@ private:
     struct ProcessorCycle instrTable[0x101 << 3];
 
 private:
-    /// Represents an instruction subcycle that writes
-    EventCallback<MOS6510> m_nosteal;
-
-    /// Represents an instruction subcycle that reads
-    EventCallback<MOS6510> m_steal;
-
-    EventCallback<MOS6510> clearInt;
-
     void eventWithoutSteals();
     void eventWithSteals();
     void removeIRQ();
+
+    /// Represents an instruction subcycle that writes
+    FastEventCallback<MOS6510, &MOS6510::eventWithoutSteals> m_nosteal;
+
+    /// Represents an instruction subcycle that reads
+    FastEventCallback<MOS6510, &MOS6510::eventWithSteals> m_steal;
+
+    FastEventCallback<MOS6510, &MOS6510::removeIRQ> clearInt;
 
     inline void Initialise();
 

--- a/src/c64/CPU/mos6510.h
+++ b/src/c64/CPU/mos6510.h
@@ -85,7 +85,7 @@ public:
 private:
     struct ProcessorCycle
     {
-        void (MOS6510::*func)();
+        void (*func)(MOS6510&);
         bool nosteal;
         ProcessorCycle() :
             func(nullptr),


### PR DESCRIPTION
Hello!

Here's some optimizations I made to my fork of libsidplayfp long time ago.
Tl;dr, calling function via member to pointer may be quite expensive due to some additional checks compiler should perform.

Some performance reports. Rendering speed shows relation between rendered sound duration and spent real time (e.g. if 60s track is rendered in 10s, metric is 6.0)

Full tracks collection (68805 unique modules, 98188 tracks) rendered on Intel Xeon.

- Original: speed=10.02..62.29 avg=27.30 median=27.50
- Only CPU instructions optimized: speed=10.38..64.18 avg=28.12 median=28.28
- Also CPU events optimized: speed=10.45..66.33 avg=29.17 median=29.33

Optimization is 6.8% by average and 6.6% by median

(My fork with additional optimizations based on ancient version: speed=7.44..72.49 avg=31.53 median=30.34)

Random 1000 files from full collection (1413 tracks) rendered on Ryzen 5 1600.

- Original: speed=19.90..41.02 avg=33.72 median=34.00
- Only CPU instructions optimized: speed=21.06..43.59 avg=38.21 median=39.05
- Also CPU events optimized: speed=20.71..44.74 avg=39.14 median=40.03

Optimization is 16% by average and 17.7% by median

(My fork shows speed=10.80..55.75 avg=44.28 median=42.54)

Random 100 files from full collection (164 tracks) rendered on ARMv6 (RaspberryPi v1)

- Original: speed=1.06..1.97 avg=1.75 median=1.77
- Only CPU instructions optimized: speed=1.13..2.09 avg=1.83 median=1.85
- Also CPU events optimized: speed=1.04..2.07 avg=1.83 median=1.85

Optimization is 4.6% by average and 4.5% by median

(My fork shows speed=1.18..3.01 avg=2.47 median=2.51)