### PR TITLE
Optimize CPU I/O processing.

### DIFF
--- a/src/c64/CPU/mos6510.cpp
+++ b/src/c64/CPU/mos6510.cpp
@@ -1469,8 +1469,9 @@ void MOS6510::rra_instr()
  * @param context
  *            The Event Context
  */
-MOS6510::MOS6510(EventScheduler &scheduler) :
+MOS6510::MOS6510(EventScheduler &scheduler, CPUDataBus &bus) :
     eventScheduler(scheduler),
+    dataBus(bus),
 #ifdef DEBUG
     m_fdbg(stdout),
 #endif

--- a/src/c64/CPU/mos6510.h
+++ b/src/c64/CPU/mos6510.h
@@ -48,6 +48,15 @@ namespace MOS6510Debug
 }
 #endif
 
+class CPUDataBus
+{
+public:
+  virtual ~CPUDataBus() = default;
+
+  virtual uint8_t cpuRead(uint_least16_t addr) =0;
+
+  virtual void cpuWrite(uint_least16_t addr, uint8_t data) =0;
+};
 
 /**
  * Cycle-exact 6502/6510 emulation core.
@@ -95,6 +104,9 @@ private:
 private:
     /// Event scheduler
     EventScheduler &eventScheduler;
+
+    /// Data bus
+    CPUDataBus &dataBus;
 
     /// Current instruction and subcycle within instruction
     int cycleCount;
@@ -297,27 +309,13 @@ private:
 
     inline void buildInstructionTable();
 
-protected:
-    MOS6510(EventScheduler &scheduler);
-    ~MOS6510() = default;
-
-    /**
-     * Get data from system environment.
-     *
-     * @param address
-     * @return data byte CPU requested
-     */
-    virtual uint8_t cpuRead(uint_least16_t addr) =0;
-
-    /**
-     * Write data to system environment.
-     *
-     * @param address
-     * @param data
-     */
-    virtual void cpuWrite(uint_least16_t addr, uint8_t data) =0;
-
 public:
+    MOS6510(EventScheduler &scheduler, CPUDataBus& bus);
+
+    inline uint8_t cpuRead(uint_least16_t addr) { return dataBus.cpuRead(addr); }
+
+    inline void cpuWrite(uint_least16_t addr, uint8_t data) { dataBus.cpuWrite(addr, data); }
+
     void reset();
 
     static const char *credits();

--- a/src/c64/c64.cpp
+++ b/src/c64/c64.cpp
@@ -82,12 +82,13 @@ double c64::getCpuFreq(model_t model)
 c64::c64() :
     c64env(eventScheduler),
     cpuFrequency(getCpuFreq(PAL_B)),
-    cpu(*this),
     cia1(*this),
     cia2(*this),
     vic(*this),
     disconnectedBusBank(mmu),
-    mmu(eventScheduler, &ioBank)
+    mmu(eventScheduler, &ioBank),
+    cpubus(mmu),
+    cpu(eventScheduler, cpubus)
 {
     resetIoBank();
 }

--- a/src/c64/c64.h
+++ b/src/c64/c64.h
@@ -104,9 +104,6 @@ private:
     /// System event context
     EventScheduler eventScheduler;
 
-    /// CPU
-    c64cpu cpu;
-
     /// CIA1
     c64cia1 cia1;
 
@@ -134,26 +131,16 @@ private:
     /// MMU chip
     MMU mmu;
 
+    /// CPUBus
+    c64cpubus cpubus;
+
+    /// CPU
+    MOS6510 cpu;
+
 private:
     static double getCpuFreq(model_t model);
 
 private:
-    /**
-     * Access memory as seen by CPU.
-     *
-     * @param addr the address where to read from
-     * @return value at address
-     */
-    uint8_t cpuRead(uint_least16_t addr) override { return mmu.cpuRead(addr); }
-
-    /**
-     * Access memory as seen by CPU.
-     *
-     * @param addr the address where to write to
-     * @param data the value to write
-     */
-    void cpuWrite(uint_least16_t addr, uint8_t data) override { mmu.cpuWrite(addr, data); }
-
     /**
      * IRQ trigger signal.
      *

--- a/src/c64/c64cpu.h
+++ b/src/c64/c64cpu.h
@@ -25,7 +25,7 @@
 #  include "config.h"
 #endif
 
-#include "c64/c64env.h"
+#include "c64/mmu.h"
 #include "CPU/mos6510.h"
 
 #ifdef VICE_TESTSUITE
@@ -65,13 +65,13 @@ static const char CHRtab[256] =
   0x2f,0x2d,0x2d,0x7c,0x7c,0x7c,0x7c,0x2d,0x2d,0x2d,0x2f,0x5c,0x5c,0x2f,0x2f,0x23
 };
 #endif
-class c64cpu final : public MOS6510
+class c64cpubus final : public CPUDataBus
 {
 private:
-    c64env &m_env;
+    MMU &m_mmu;
 
 protected:
-    uint8_t cpuRead(uint_least16_t addr) override { return m_env.cpuRead(addr); }
+    uint8_t cpuRead(uint_least16_t addr) override { return m_mmu.cpuRead(addr); }
 
     void cpuWrite(uint_least16_t addr, uint8_t data) override
     {
@@ -97,13 +97,12 @@ protected:
             }
         }
 #endif
-        m_env.cpuWrite(addr, data);
+        m_mmu.cpuWrite(addr, data);
     }
 
 public:
-    c64cpu (c64env &env) :
-        MOS6510(env.scheduler()),
-        m_env(env) {}
+    c64cpubus (MMU &mmu) :
+        m_mmu(mmu) {}
 };
 
 }

--- a/src/c64/c64env.h
+++ b/src/c64/c64env.h
@@ -48,9 +48,6 @@ public:
 
     EventScheduler &scheduler() const { return eventScheduler; }
 
-    virtual uint8_t cpuRead(uint_least16_t addr) =0;
-    virtual void cpuWrite(uint_least16_t addr, uint8_t data) =0;
-
     virtual void interruptIRQ(bool state) = 0;
     virtual void interruptNMI() = 0;
     virtual void interruptRST() = 0;

--- a/tests/TestMos6510.cpp
+++ b/tests/TestMos6510.cpp
@@ -37,7 +37,7 @@
 using namespace UnitTest;
 using namespace libsidplayfp;
 
-class testcpu final : public MOS6510
+class testcpu final : public MOS6510, public CPUDataBus
 {
 private:
     uint8_t mem[65536];
@@ -52,7 +52,7 @@ protected:
 
 public:
     testcpu(EventScheduler &scheduler) :
-        MOS6510(scheduler)
+        MOS6510(scheduler, *this)
     {
         mem[0xFFFC] = 0x00;
         mem[0xFFFD] = 0x10;


### PR DESCRIPTION
Hello!

This optimization improves I/O for emulated CPU via introducing CPUDataBus abstraction. Previously there were some redundant virtual calls:
 MOS6510::cpuRead -(via c64cpu::cpuRead)-> c64env::cpuRead -(via c64::cpuRead and MMU::cpuRead)-> Bank::peek

Now chain is:
CPUDataBus::cpuRead -(via c64cpubus and MMU::cpuRead)-> Bank::peek

Performance reports (follow-up for #131 ).

98188 tracks rendered on Intel Xeon:
Before: speed=10.45..66.33 avg=29.17 median=29.33
After: speed=9.89..65.49 avg=28.55 median=28.74
Delta: -2.2%/-2.1% (TBH have not idea about degradation reason)

1413 tracks rendered on Ryzen 5 1600:
Before: speed=20.71..44.74 avg=39.14 median=40.03
After: speed=21.82..45.06 avg=40.23 median=41.06
Delta: 2.8%/2.6%

164 tracks rendered on Raspberry Pi 1 (32-bit ARMv6 700MHz):
Before: speed=1.04..2.07 avg=1.83 median=1.85
After: speed=1.14..2.25 avg=1.96 median=2.00
Delta: 7.1%/8.1%

UPD: 164 tracks rendered on Raspberry Pi 3B+ (64-bit ARMv8 1.4GHz):
Before: speed=2.39..3.40 avg=3.06 median=3.03
After: speed=2.48..3.56 avg=3.18 median=3.15
Delta: 3.9%/4%

