### PR TITLE
Optimize virtual functions calls in MMU.

### DIFF
--- a/src/c64/mmu.h
+++ b/src/c64/mmu.h
@@ -55,8 +55,11 @@ private:
     /// CPU port signals
     bool loram, hiram, charen;
 
+    friend uint8_t readIO(MMU &self, uint_least16_t addr);
+    using ReadFunc = uint8_t (*)(MMU &self, uint_least16_t addr);
+
     /// CPU read memory mapping in 4k chunks
-    Bank* cpuReadMap[16];
+    ReadFunc cpuReadMap[16];
 
     /// CPU write memory mapping in 4k chunks
     Bank* cpuWriteMap[16];
@@ -128,7 +131,7 @@ public:
      * @param addr the address where to read from
      * @return value at address
      */
-    uint8_t cpuRead(uint_least16_t addr) const { return cpuReadMap[addr >> 12]->peek(addr); }
+    uint8_t cpuRead(uint_least16_t addr) { return (cpuReadMap[addr >> 12])(*this, addr); }
 
     /**
      * Access memory as seen by CPU.


### PR DESCRIPTION
Hi!

This patch helps compiler to optimize virtual function call in order to speedup MMU. Profiles and performance reports for 1.4GHz ARM64 CPU by default

### Test for random 100 sid files (164 tracks)

Before: speed=2.61..3.91 avg=3.37 median=3.34
After: speed=2.65..4.29 avg=3.46 median=3.44
Delta: 2.7%/3%

### Test for 10 digital sid files (92 tracks) from #133 

Before: speed=2.61..4.45 avg=3.27 median=3.29
After: speed=2.64..5.91 avg=3.39 median=3.38
Delta: 3.7%/2.7%

### Test for 1000 random sid files (1413 tracks) at Ryzen 5 1600:
Before: speed=21.82..45.06 avg=40.23 median=41.06
After: speed=22.15..45.82 avg=40.55 median=41.36
Delta: 0.8%/0.7%

In attachment there are profiling details - as you can see `c64cpubus::cpuRead` consumes less time due to unneeded virtual function pointer acquiring.
[before_random.txt](https://github.com/user-attachments/files/16082214/before_random.txt)
[before_digital.txt](https://github.com/user-attachments/files/16082218/before_digital.txt)
[after_random.txt](https://github.com/user-attachments/files/16082217/after_random.txt)
[after_digital.txt](https://github.com/user-attachments/files/16082215/after_digital.txt)
