### PR TITLE
Add new centralized API to toggle the filter

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -192,6 +192,13 @@ void Player::mute(unsigned int sidNum, unsigned int voice, bool enable)
         s->voice(voice, enable);
 }
 
+void Player::filter(unsigned int sidNum, bool enable)
+{
+    sidemu *s = m_mixer.getSid(sidNum);
+    if (s != nullptr)
+        s->filter(enable);
+}
+
 /**
  * @throws MOS6510::haltInstruction
  */

--- a/src/player.h
+++ b/src/player.h
@@ -155,6 +155,8 @@ public:
 
     void mute(unsigned int sidNum, unsigned int voice, bool enable);
 
+    void filter(unsigned int sidNum, bool enable);
+
     const char *error() const { return m_errorString; }
 
     void setKernal(const uint8_t* rom);

--- a/src/sidemu.cpp
+++ b/src/sidemu.cpp
@@ -42,6 +42,9 @@ void sidemu::writeReg(uint_least8_t addr, uint8_t data)
     case 0x12:
         if (isMuted[2]) data &= 0x0f;
         break;
+    case 0x17:
+        if (isFilterDisabled) data &= 0xf0;
+        break;
     case 0x18:
         if (isMuted[3]) data |= 0x0f;
         break;
@@ -54,6 +57,11 @@ void sidemu::voice(unsigned int voice, bool mute)
 {
     if (voice < 4)
         isMuted[voice] = mute;
+}
+
+void sidemu::filter(bool enable)
+{
+    isFilterDisabled = !enable;
 }
 
 bool sidemu::lock(EventScheduler *scheduler)

--- a/src/sidemu.h
+++ b/src/sidemu.h
@@ -71,6 +71,8 @@ protected:
     bool m_status = true;
     bool isLocked = false;
 
+    bool isFilterDisabled = false;
+
     /// Flags for muted voices
     std::bitset<4> isMuted;
 
@@ -114,6 +116,11 @@ public:
      * @param mute true to mute channel
      */
     void voice(unsigned int voice, bool mute);
+
+    /**
+     * Enable/disable filter.
+     */
+    void filter(bool enable);
 
     /**
      * Set SID model.

--- a/src/sidplayfp/sidbuilder.h
+++ b/src/sidplayfp/sidbuilder.h
@@ -135,7 +135,9 @@ public:
      * Toggle sid filter emulation.
      *
      * @param enable true = enable, false = disable
+     * @deprecated use #sidplayfp.filter
      */
+    SID_DEPRECATED
     virtual void filter(bool enable) = 0;
 };
 

--- a/src/sidplayfp/sidplayfp.cpp
+++ b/src/sidplayfp/sidplayfp.cpp
@@ -96,6 +96,11 @@ void sidplayfp::mute(unsigned int sidNum, unsigned int voice, bool enable)
     sidplayer.mute(sidNum, voice, enable);
 }
 
+void sidplayfp::filter(unsigned int sidNum, bool enable)
+{
+    sidplayer.filter(sidNum, enable);
+}
+
 void sidplayfp::debug(bool enable, FILE *out)
 {
     sidplayer.debug(enable, out);

--- a/src/sidplayfp/sidplayfp.h
+++ b/src/sidplayfp/sidplayfp.h
@@ -142,6 +142,15 @@ public:
     void mute(unsigned int sidNum, unsigned int voice, bool enable);
 
     /**
+     * Enable/disable SID filter.
+     *
+     * @param sidNum the SID chip, 0 for the first one, 1 for the second or 2 for the third.
+     * @param enable true enable the filter, false disable it.
+     * @since 2.10
+     */
+    void filter(unsigned int sidNum, bool enable);
+
+    /**
      * Get the current playing time.
      *
      * @return the current playing time measured in seconds.


### PR DESCRIPTION
A generic API to "soft" toggle the filter by inhibiting writes to the filter routing register.
The sidbuilder filter function is deprecated and will be kept only for software emulations to "hard" disable the filter.