### PR TITLE
New play api (#41)

### DIFF
--- a/src/c64/c64.h
+++ b/src/c64/c64.h
@@ -258,6 +258,8 @@ public:
     sidmemory& getMemInterface() { return mmu; }
 
     uint_least16_t getCia1TimerA() const { return cia1.getTimerA(); }
+
+    unsigned int installedSIDs() const { return 1 + extraSidBanks.size(); }
 };
 
 void c64::interruptIRQ(bool state)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -218,6 +218,36 @@ void Player::filter(unsigned int sidNum, bool enable)
         s->filter(enable);
 }
 
+uint_least32_t Player::play(unsigned int cycles, short* (&buffers)[])
+{
+    try
+    {
+        for (unsigned int i = 0; i < cycles; i++)
+            m_c64.clock();
+
+        int sampleCount = 0;
+        for (int i = 0; i < 3; i++)
+        {
+            sidemu *s = m_mixer.getSid(i);
+            if (s)
+            {
+                s->clock();
+                sampleCount = s->bufferpos();
+                buffers[i] = s->buffer();
+                s->bufferpos(0);
+            }
+            else
+                buffers[i] = nullptr;
+        }
+        return sampleCount;
+    }
+    catch (MOS6510::haltInstruction const &)
+    {
+        m_errorString = "Illegal instruction executed";
+        return 0;
+    }
+}
+
 /**
  * @throws MOS6510::haltInstruction
  */

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -226,14 +226,18 @@ uint_least32_t Player::play(unsigned int cycles, short* (&buffers)[])
             m_c64.clock();
 
         int sampleCount = 0;
-        for (int i = 0; i < 3; i++)
+        for (unsigned int i = 0; i < Mixer::MAX_SIDS; i++)
         {
             sidemu *s = m_mixer.getSid(i);
             if (s)
             {
+                // clock the chip and get the buffer
+                // buffersize is expected to be the same
+                // for all chips
                 s->clock();
                 sampleCount = s->bufferpos();
                 buffers[i] = s->buffer();
+                // Reset the buffer
                 s->bufferpos(0);
             }
             else

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -218,7 +218,16 @@ void Player::filter(unsigned int sidNum, bool enable)
         s->filter(enable);
 }
 
-uint_least32_t Player::play(unsigned int cycles, short* (&buffers)[])
+void Player::buffers(short* (&buffers)[3]) const
+{
+    for (unsigned int i = 0; i < Mixer::MAX_SIDS; i++)
+    {
+        sidemu *s = m_mixer.getSid(i);
+        buffers[i] = s ? s->buffer() : nullptr;
+    }
+}
+
+uint_least32_t Player::play(unsigned int cycles)
 {
     try
     {
@@ -236,12 +245,9 @@ uint_least32_t Player::play(unsigned int cycles, short* (&buffers)[])
                 // for all chips
                 s->clock();
                 sampleCount = s->bufferpos();
-                buffers[i] = s->buffer();
                 // Reset the buffer
                 s->bufferpos(0);
             }
-            else
-                buffers[i] = nullptr;
         }
         return sampleCount;
     }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -218,7 +218,7 @@ void Player::filter(unsigned int sidNum, bool enable)
         s->filter(enable);
 }
 
-void Player::buffers(short* (&buffers)[3]) const
+void Player::buffers(short** buffers) const
 {
     for (unsigned int i = 0; i < Mixer::MAX_SIDS; i++)
     {

--- a/src/player.h
+++ b/src/player.h
@@ -172,6 +172,8 @@ public:
     uint_least16_t getCia1TimerA() const { return m_c64.getCia1TimerA(); }
 
     bool getSidStatus(unsigned int sidNum, uint8_t regs[32]);
+
+    unsigned int installedSIDs() const { return m_c64.installedSIDs(); }
 };
 
 }

--- a/src/player.h
+++ b/src/player.h
@@ -147,7 +147,7 @@ public:
 
     uint_least32_t play(short *buffer, uint_least32_t samples);
 
-    void buffers(short* (&buffers)[3]) const;
+    void buffers(short** buffers) const;
 
     uint_least32_t play(unsigned int cycles);
 

--- a/src/player.h
+++ b/src/player.h
@@ -147,6 +147,8 @@ public:
 
     uint_least32_t play(short *buffer, uint_least32_t samples);
 
+    uint_least32_t play(unsigned int cycles, short* (&buffers)[]);
+
     bool isPlaying() const { return m_isPlaying != state_t::STOPPED; }
 
     void stop();

--- a/src/player.h
+++ b/src/player.h
@@ -147,7 +147,9 @@ public:
 
     uint_least32_t play(short *buffer, uint_least32_t samples);
 
-    uint_least32_t play(unsigned int cycles, short* (&buffers)[]);
+    void buffers(short* (&buffers)[3]) const;
+
+    uint_least32_t play(unsigned int cycles);
 
     bool isPlaying() const { return m_isPlaying != state_t::STOPPED; }
 

--- a/src/sidplayfp/sidplayfp.cpp
+++ b/src/sidplayfp/sidplayfp.cpp
@@ -61,6 +61,11 @@ uint_least32_t sidplayfp::play(short *buffer, uint_least32_t count)
     return sidplayer.play(buffer, count);
 }
 
+uint_least32_t sidplayfp::play(unsigned int cycles, short* (&buffers)[])
+{
+    return sidplayer.play(cycles, buffers);
+}
+
 bool sidplayfp::load(SidTune *tune)
 {
     return sidplayer.load(tune);

--- a/src/sidplayfp/sidplayfp.cpp
+++ b/src/sidplayfp/sidplayfp.cpp
@@ -61,7 +61,7 @@ uint_least32_t sidplayfp::play(short *buffer, uint_least32_t count)
     return sidplayer.play(buffer, count);
 }
 
-void sidplayfp::buffers(short* (&buffers)[3]) const
+void sidplayfp::buffers(short** buffers) const
 {
     sidplayer.buffers(buffers);
 }

--- a/src/sidplayfp/sidplayfp.cpp
+++ b/src/sidplayfp/sidplayfp.cpp
@@ -141,3 +141,8 @@ bool sidplayfp::getSidStatus(unsigned int sidNum, uint8_t regs[32])
 {
     return sidplayer.getSidStatus(sidNum, regs);
 }
+
+unsigned int sidplayfp::installedSIDs() const
+{
+    return sidplayer.installedSIDs();
+}

--- a/src/sidplayfp/sidplayfp.cpp
+++ b/src/sidplayfp/sidplayfp.cpp
@@ -61,9 +61,14 @@ uint_least32_t sidplayfp::play(short *buffer, uint_least32_t count)
     return sidplayer.play(buffer, count);
 }
 
-uint_least32_t sidplayfp::play(unsigned int cycles, short* (&buffers)[])
+void sidplayfp::buffers(short* (&buffers)[3]) const
 {
-    return sidplayer.play(cycles, buffers);
+    sidplayer.buffers(buffers);
+}
+
+uint_least32_t sidplayfp::play(unsigned int cycles)
+{
+    return sidplayer.play(cycles);
 }
 
 bool sidplayfp::load(SidTune *tune)

--- a/src/sidplayfp/sidplayfp.cpp
+++ b/src/sidplayfp/sidplayfp.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2022 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2000-2001 Simon White
  *

--- a/src/sidplayfp/sidplayfp.h
+++ b/src/sidplayfp/sidplayfp.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2024 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2000 Simon White
  *
@@ -110,9 +110,29 @@ public:
      */
     uint_least32_t play(short *buffer, uint_least32_t count);
 
-    /// Experimental
+    /**
+     * Get the buffers.
+     *
+     * @param buffers pointer to the array of buffer pointers.
+     * @since 2.14
+     */
     void buffers(short** buffers) const;
+
+    /**
+     * Run the emulation.
+     *
+     * @param cycles the number of cycles to run.
+     * @return the number of produced samples.
+     * @since 2.14
+     */
     uint_least32_t play(unsigned int cycles);
+
+    /**
+     * Get the number of installed SID chips.
+     *
+     * @return the number of SID chips.
+     * @since 2.14
+     */
     unsigned int installedSIDs() const;
 
     /**

--- a/src/sidplayfp/sidplayfp.h
+++ b/src/sidplayfp/sidplayfp.h
@@ -113,6 +113,7 @@ public:
     /// Experimental
     void buffers(short** buffers) const;
     uint_least32_t play(unsigned int cycles);
+    unsigned int installedSIDs() const;
 
     /**
      * Check if the engine is playing or stopped.

--- a/src/sidplayfp/sidplayfp.h
+++ b/src/sidplayfp/sidplayfp.h
@@ -110,6 +110,9 @@ public:
      */
     uint_least32_t play(short *buffer, uint_least32_t count);
 
+    /// Experimental
+    uint_least32_t play(unsigned int cycles, short* (&buffers)[]);
+
     /**
      * Check if the engine is playing or stopped.
      *

--- a/src/sidplayfp/sidplayfp.h
+++ b/src/sidplayfp/sidplayfp.h
@@ -111,7 +111,7 @@ public:
     uint_least32_t play(short *buffer, uint_least32_t count);
 
     /// Experimental
-    void buffers(short* (&buffers)[3]) const;
+    void buffers(short** buffers) const;
     uint_least32_t play(unsigned int cycles);
 
     /**

--- a/src/sidplayfp/sidplayfp.h
+++ b/src/sidplayfp/sidplayfp.h
@@ -111,7 +111,8 @@ public:
     uint_least32_t play(short *buffer, uint_least32_t count);
 
     /// Experimental
-    uint_least32_t play(unsigned int cycles, short* (&buffers)[]);
+    void buffers(short* (&buffers)[3]) const;
+    uint_least32_t play(unsigned int cycles);
 
     /**
      * Check if the engine is playing or stopped.


### PR DESCRIPTION
`unsigned int sidplayfp::installedSIDs() const;` to get the number of SIDs installed in the emulation engine;
`void sidplayfp::buffers(short** buffers) const;` to get the pointers to the SID buffers;
`uint_least32_t sidplayfp::play(unsigned int cycles);` to run the emulation for the selected number of cycles.