### PR TITLE
Create sid emu on locking

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,6 +106,7 @@ src/psiddrv.bin \
 src/mixer.cpp \
 src/mixer.h \
 src/poweron.bin \
+src/properties.h \
 src/reloc65.cpp \
 src/reloc65.h \
 src/sidcxx11.h \

--- a/src/builders/exsid-builder/exsid-builder.cpp
+++ b/src/builders/exsid-builder/exsid-builder.cpp
@@ -22,15 +22,22 @@
 #include <sstream>
 #include <string>
 
+#include "properties.h"
 #include "exsid.h"
 #include "exsid-emu.h"
 
+
+struct exSIDBuilder::config
+{
+    Property<bool> filterEnabled;
+};
 
 bool exSIDBuilder::m_initialised = false;
 unsigned int exSIDBuilder::m_count = 0;
 
 exSIDBuilder::exSIDBuilder(const char * const name) :
-    sidbuilder(name)
+    sidbuilder(name),
+    m_config(new config)
 {
     if (!m_initialised)
     {
@@ -43,6 +50,8 @@ exSIDBuilder::~exSIDBuilder()
 {
     // Remove all SID emulations
     remove();
+
+    delete m_config;
 }
 
 // Create a new sid emulation.  Called by libsidplay2 only
@@ -74,6 +83,8 @@ unsigned int exSIDBuilder::create(unsigned int sids)
                 goto exSIDBuilder_create_error;
             }
 
+            if (m_config->filterEnabled.has_value())
+                sid->filter(m_config->filterEnabled.value());
             sidobjs.insert(sid.release());
         }
         // Memory alloc failed?
@@ -108,6 +119,7 @@ void exSIDBuilder::flush()
 
 void exSIDBuilder::filter (bool enable)
 {
+    m_config->filterEnabled = enable;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::exSID*>(e)->filter(enable);
 }

--- a/src/builders/exsid-builder/exsid.h
+++ b/src/builders/exsid-builder/exsid.h
@@ -40,10 +40,14 @@ public:
     const char *credits() const;
     void flush();
 
+    /// @name global settings
+    /// Settings that affect all SIDs.
+    //@{
     /**
      * enable/disable filter.
      */
     void filter(bool enable);
+    //@}
 
     /**
      * Create the sid emu.
@@ -51,6 +55,9 @@ public:
      * @param sids the number of required sid emu
      */
     unsigned int create(unsigned int sids);
+private:
+    struct config;
+    config *m_config;
 };
 
 #endif // EXSID_H

--- a/src/builders/hardsid-builder/hardsid.h
+++ b/src/builders/hardsid-builder/hardsid.h
@@ -55,10 +55,14 @@ public:
 
     void flush();
 
+    /// @name global settings
+    /// Settings that affect all SIDs.
+    //@{
     /**
      * enable/disable filter.
      */
     void filter(bool enable);
+    //@}
 
     /**
      * Create the sid emu.
@@ -66,6 +70,9 @@ public:
      * @param sids the number of required sid emu
      */
     unsigned int create(unsigned int sids);
+private:
+    struct config;
+    config *m_config;
 };
 
 #endif // HARDSID_H

--- a/src/builders/resid-builder/resid-builder.cpp
+++ b/src/builders/resid-builder/resid-builder.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2024 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2001 Simon White
  *
@@ -25,11 +25,24 @@
 #include <algorithm>
 #include <new>
 
+#include "properties.h"
 #include "resid-emu.h"
+
+struct ReSIDBuilder::config
+{
+    Property<double> bias;
+    Property<bool> filterEnabled;
+};
+
+ReSIDBuilder::ReSIDBuilder(const char * const name) :
+    sidbuilder(name),
+    m_config(new config) {}
 
 ReSIDBuilder::~ReSIDBuilder()
 {   // Remove all SID emulations
     remove();
+
+    delete m_config;
 }
 
 // Create a new sid emulation.
@@ -47,7 +60,12 @@ unsigned int ReSIDBuilder::create(unsigned int sids)
     {
         try
         {
-            sidobjs.insert(new libsidplayfp::ReSID(this));
+            auto sid = new libsidplayfp::ReSID(this);
+            if (m_config->bias.has_value())
+                sid->bias(m_config->bias.value());
+            if (m_config->filterEnabled.has_value())
+                sid->filter(m_config->filterEnabled.value());
+            sidobjs.insert(sid);
         }
         // Memory alloc failed?
         catch (std::bad_alloc const &)
@@ -67,12 +85,14 @@ const char *ReSIDBuilder::credits() const
 
 void ReSIDBuilder::filter(bool enable)
 {
+    m_config->filterEnabled = enable;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::ReSID*>(e)->filter(enable);
 }
 
 void ReSIDBuilder::bias(double dac_bias)
 {
+    m_config->bias = dac_bias;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::ReSID*>(e)->bias(dac_bias);
 }

--- a/src/builders/resid-builder/resid.h
+++ b/src/builders/resid-builder/resid.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2013 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2001 Simon White
  *
@@ -32,8 +32,7 @@
 class SID_EXTERN ReSIDBuilder : public sidbuilder
 {
 public:
-    ReSIDBuilder(const char * const name) :
-        sidbuilder(name) {}
+    ReSIDBuilder(const char * const name);
     ~ReSIDBuilder();
 
     /**
@@ -61,6 +60,9 @@ public:
      */
     void bias(double dac_bias);
     //@}
+private:
+    struct config;
+    config *m_config;
 };
 
 #endif // RESID_H

--- a/src/builders/residfp-builder/residfp-builder.cpp
+++ b/src/builders/residfp-builder/residfp-builder.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2024 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2001 Simon White
  *
@@ -24,12 +24,31 @@
 
 #include <algorithm>
 #include <new>
+#include <utility>
 
+#include "properties.h"
 #include "residfp-emu.h"
 
+struct ReSIDfpBuilder::config
+{
+    Property<double> filter8580Curve;
+    Property<double> filter6581Curve;
+    Property<double> filter6581Range;
+    Property<SidConfig::sid_cw_t> cws;
+    Property<bool> filterEnabled;
+};
+
+
+ReSIDfpBuilder::ReSIDfpBuilder(const char * const name) :
+    sidbuilder(name),
+    m_config(new config) {}
+
 ReSIDfpBuilder::~ReSIDfpBuilder()
-{   // Remove all SID emulations
+{
+    // Remove all SID emulations
     remove();
+
+    delete m_config;
 }
 
 // Create a new sid emulation.
@@ -47,7 +66,18 @@ unsigned int ReSIDfpBuilder::create(unsigned int sids)
     {
         try
         {
-            sidobjs.insert(new libsidplayfp::ReSIDfp(this));
+            auto sid = new libsidplayfp::ReSIDfp(this);
+            if (m_config->filter6581Curve.has_value())
+                sid->filter6581Curve(m_config->filter6581Curve.value());
+            if (m_config->filter8580Curve.has_value())
+                sid->filter8580Curve(m_config->filter8580Curve.value());
+            if (m_config->filter6581Range.has_value())
+                sid->filter6581Range(m_config->filter6581Range.value());
+            if (m_config->cws.has_value())
+                sid->combinedWaveforms(m_config->cws.value());
+            if (m_config->filterEnabled.has_value())
+                sid->filter(m_config->filterEnabled.value());
+            sidobjs.insert(sid);
         }
         // Memory alloc failed?
         catch (std::bad_alloc const &)
@@ -68,30 +98,35 @@ const char *ReSIDfpBuilder::credits() const
 
 void ReSIDfpBuilder::filter(bool enable)
 {
+    m_config->filterEnabled = enable;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::ReSIDfp*>(e)->filter(enable);
 }
 
 void ReSIDfpBuilder::filter6581Curve(double filterCurve)
 {
+    m_config->filter6581Curve = filterCurve;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::ReSIDfp*>(e)->filter6581Curve(filterCurve);
 }
 
 void ReSIDfpBuilder::filter6581Range(double filterRange)
 {
+    m_config->filter6581Range = filterRange;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::ReSIDfp*>(e)->filter6581Range(filterRange);
 }
 
 void ReSIDfpBuilder::filter8580Curve(double filterCurve)
 {
+    m_config->filter8580Curve = filterCurve;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::ReSIDfp*>(e)->filter8580Curve(filterCurve);
 }
 
 void ReSIDfpBuilder::combinedWaveformsStrength(SidConfig::sid_cw_t cws)
 {
+    m_config->cws = cws;
     for (libsidplayfp::sidemu* e: sidobjs)
         static_cast<libsidplayfp::ReSIDfp*>(e)->combinedWaveforms(cws);
 }

--- a/src/builders/residfp-builder/residfp.h
+++ b/src/builders/residfp-builder/residfp.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2013 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2001 Simon White
  *
@@ -32,8 +32,7 @@
 class SID_EXTERN ReSIDfpBuilder: public sidbuilder
 {
 public:
-    ReSIDfpBuilder(const char * const name) :
-        sidbuilder(name) {}
+    ReSIDfpBuilder(const char * const name);
     ~ReSIDfpBuilder();
 
     /**
@@ -87,8 +86,10 @@ public:
      * @param cws 
      */
     void combinedWaveformsStrength(SidConfig::sid_cw_t cws);
-
     //@}
+private:
+    struct config;
+    config *m_config;
 };
 
 #endif // RESIDFP_H

--- a/src/properties.h
+++ b/src/properties.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of libsidplayfp, a SID player engine.
+ *
+ * Copyright 2025 Leandro Nini <drfiemost@users.sourceforge.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef PROPERTIES_H
+#define PROPERTIES_H
+
+#include "sidcxx11.h"
+
+#ifdef HAVE_CXX17
+
+#include <optional>
+
+template <typename T>
+using Property = std::optional<T>;
+
+#else
+
+#include <type_traits>
+
+template <typename T>
+class Property
+{
+    static_assert(std::is_scalar<T>(), "T must be a scalar type");
+
+private:
+    T m_val;
+    bool m_isSet;
+
+public:
+    Property() :
+        m_isSet(false) {}
+
+    inline bool has_value() const { return m_isSet; }
+    inline T value() const { return m_val; }
+    inline Property<T>& operator =(const T& val) { m_val = val; m_isSet = true;  return *this; }
+};
+
+#endif // HAVE_CXX17
+
+#endif // PROPERTIES_H

--- a/src/sidplayfp/sidbuilder.cpp
+++ b/src/sidplayfp/sidbuilder.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2019 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2000-2001 Simon White
  *
@@ -30,12 +30,27 @@ libsidplayfp::sidemu *sidbuilder::lock(libsidplayfp::EventScheduler *env, SidCon
 {
     m_status = true;
 
+    // TODO cleanup once we remove sidbuilder::create
+
     for (libsidplayfp::sidemu *sid: sidobjs)
     {
         if (sid->lock(env))
         {
             sid->model(model, digiboost);
             return sid;
+        }
+    }
+
+    unsigned int res = create(1);
+    if (res)
+    {
+        for (libsidplayfp::sidemu *sid: sidobjs)
+        {
+            if (sid->lock(env))
+            {
+                sid->model(model, digiboost);
+                return sid;
+            }
         }
     }
 
@@ -51,6 +66,9 @@ void sidbuilder::unlock(libsidplayfp::sidemu *device)
     if (it != sidobjs.end())
     {
         (*it)->unlock();
+        // TODO should we remove it or cache for later use?
+        //sidobjs.erase(it);
+        //delete *it;
     }
 }
 

--- a/src/sidplayfp/sidbuilder.h
+++ b/src/sidplayfp/sidbuilder.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsidplayfp, a SID player engine.
  *
- * Copyright 2011-2024 Leandro Nini <drfiemost@users.sourceforge.net>
+ * Copyright 2011-2025 Leandro Nini <drfiemost@users.sourceforge.net>
  * Copyright 2007-2010 Antti Lankila
  * Copyright 2000-2001 Simon White
  *
@@ -78,6 +78,7 @@ public:
      *
      * @param sids the number of required sid emu
      * @return the number of actually created sid emus
+     * @deprecated
      */
     virtual unsigned int create(unsigned int sids) = 0;
 
@@ -100,6 +101,7 @@ public:
 
     /**
      * Remove all SID emulations.
+     * @deprecated
      */
     void remove();
 

--- a/test/demo.cpp
+++ b/test/demo.cpp
@@ -97,12 +97,6 @@ int main(int, char* argv[])
     // Set up a SID builder
     std::unique_ptr<ReSIDfpBuilder> rs(new ReSIDfpBuilder("Demo"));
 
-    // Get the number of SIDs supported by the engine
-    unsigned int maxsids = (m_engine.info ()).maxsids();
-
-    // Create SID emulators
-    rs->create(maxsids);
-
     // Check if builder is ok
     if (!rs->getStatus())
     {
@@ -156,17 +150,18 @@ int main(int, char* argv[])
 
     uint_least32_t bufferSamples = static_cast<uint_least32_t>(bufferSize) / sizeof(short);
 
-    // Play
-    std::vector<short> buffer(bufferSamples);
+    // Play for ~5 seconds
+    short* buffers[3];
+    m_engine.buffers(buffers);
     for (int i=0; i<1000; i++)
     {
-        uint_least32_t res = m_engine.play(&buffer.front(), bufferSamples);
-        if (!m_engine.isPlaying() || (res < bufferSamples))
+        int res = m_engine.play(5000);
+        if (res < 0)
         {
-            std::cerr <<  m_engine.error() << std::endl;
+            std::cerr << m_engine.error() << std::endl;
             break;
         }
-        ::write(handle, &buffer.front(), bufferSize);
+        ::write(handle, buffers[0], res*sizeof(short));
     }
 
     ::close(handle);


### PR DESCRIPTION
do not require call to sidbuilder::create, only necessary SIDs will be created/locked
