### PR TITLE
Change VIC-II linecycle init value based on VICE

### DIFF
--- a/src/c64/VIC_II/mos656x.cpp
+++ b/src/c64/VIC_II/mos656x.cpp
@@ -87,7 +87,7 @@ void MOS656X::reset()
     irqMask             = 0;
     yscroll             = 0;
     rasterY             = maxRasters - 1;
-    lineCycle           = 0;
+    lineCycle           = 6;
     areBadLinesEnabled  = false;
     isBadLine           = false;
     rasterYIRQCondition = false;


### PR DESCRIPTION
although Denise sets it to 10...

https://bitbucket.org/piciji/denise/src/f8f02f5cb54fae93435a3d8669e56d75c4f538c8/emulation/libc64/vicII/base.cpp#lines-238

https://sourceforge.net/p/vice-emu/code/HEAD/tree/trunk/vice/src/viciisc/vicii.c#l291
