### PR TITLE
Please delete the object the pointer points to before calling erase(), since the later invalidates the iterator.

### DIFF
--- a/src/sidplayfp/sidbuilder.cpp
+++ b/src/sidplayfp/sidbuilder.cpp
@@ -53,8 +53,8 @@ void sidbuilder::unlock(libsidplayfp::sidemu *device)
     {
         (*it)->unlock();
         // should we cache these for later use?
-        sidobjs.erase(it);
         delete *it;
+        sidobjs.erase(it);
     }
 }
 


### PR DESCRIPTION
I'm updating my minor fork of libsidplayfp, and stumbled across this issue with valgrind.

```
==3004954== Invalid read of size 8
==3004954==    at 0x707B0B6: sidbuilder::unlock(libsidplayfp::sidemu*) (sidbuilder.cpp:57)
==3004954==    by 0x70778D0: libsidplayfp::Player::sidRelease() (player.cpp:529)
==3004954==    by 0x70782B0: libsidplayfp::Player::config(SidConfig const&, bool) (player.cpp:330)
==3004954==    by 0x70838A4: libsidplayfp::ConsolePlayer::clearSidEmu() (libsidplayfp-api.cpp:370)
==3004954==    by 0x7083D23: libsidplayfp::ConsolePlayer::close() (libsidplayfp-api.cpp:545)
==3004954==    by 0x7083D63: libsidplayfp::ConsolePlayer::~ConsolePlayer() (libsidplayfp-api.cpp:328)
==3004954==    by 0x7083F8C: libsidplayfp::ConsolePlayer::~ConsolePlayer() (libsidplayfp-api.cpp:330)
==3004954==    by 0x7053B25: sidClosePlayer(cpifaceSessionAPI_t*) (sidplay.cpp:1065)
==3004954==    by 0x7054C8C: sidCloseFile(cpifaceSessionAPI_t*) (sidpplay.cpp:315)
==3004954==    by 0x4EEEAC9: plmpCloseFile (cpiface.c:2432)
==3004954==    by 0x4F46CD8: _fsMain (pfsmain.c:387)
==3004954==    by 0x4ED4F57: init_modules (pmain.c:1113)
==3004954==  Address 0x7df3050 is 32 bytes inside a block of size 40 free'd
==3004954==    at 0x484E8AD: operator delete(void*, unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3004954==    by 0x707B0B5: deallocate (new_allocator.h:172)
==3004954==    by 0x707B0B5: deallocate (allocator.h:208)
==3004954==    by 0x707B0B5: deallocate (alloc_traits.h:550)
==3004954==    by 0x707B0B5: _M_put_node (stl_tree.h:563)
==3004954==    by 0x707B0B5: _M_drop_node (stl_tree.h:630)
==3004954==    by 0x707B0B5: _M_erase_aux (stl_tree.h:2494)
==3004954==    by 0x707B0B5: erase (stl_tree.h:1194)
==3004954==    by 0x707B0B5: erase (stl_set.h:657)
==3004954==    by 0x707B0B5: sidbuilder::unlock(libsidplayfp::sidemu*) (sidbuilder.cpp:56)
==3004954==    by 0x70778D0: libsidplayfp::Player::sidRelease() (player.cpp:529)
==3004954==    by 0x70782B0: libsidplayfp::Player::config(SidConfig const&, bool) (player.cpp:330)
==3004954==    by 0x70838A4: libsidplayfp::ConsolePlayer::clearSidEmu() (libsidplayfp-api.cpp:370)
==3004954==    by 0x7083D23: libsidplayfp::ConsolePlayer::close() (libsidplayfp-api.cpp:545)
==3004954==    by 0x7083D63: libsidplayfp::ConsolePlayer::~ConsolePlayer() (libsidplayfp-api.cpp:328)
==3004954==    by 0x7083F8C: libsidplayfp::ConsolePlayer::~ConsolePlayer() (libsidplayfp-api.cpp:330)
==3004954==    by 0x7053B25: sidClosePlayer(cpifaceSessionAPI_t*) (sidplay.cpp:1065)
==3004954==    by 0x7054C8C: sidCloseFile(cpifaceSessionAPI_t*) (sidpplay.cpp:315)
==3004954==    by 0x4EEEAC9: plmpCloseFile (cpiface.c:2432)
==3004954==    by 0x4F46CD8: _fsMain (pfsmain.c:387)
==3004954==  Block was alloc'd at
==3004954==    at 0x484AFD3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3004954==    by 0x707B4C7: allocate (new_allocator.h:151)
==3004954==    by 0x707B4C7: allocate (allocator.h:196)
==3004954==    by 0x707B4C7: allocate (alloc_traits.h:515)
==3004954==    by 0x707B4C7: _M_get_node (stl_tree.h:559)
==3004954==    by 0x707B4C7: _M_create_node<libsidplayfp::sidemu* const&> (stl_tree.h:609)
==3004954==    by 0x707B4C7: operator()<libsidplayfp::sidemu* const&> (stl_tree.h:527)
==3004954==    by 0x707B4C7: _M_insert_<libsidplayfp::sidemu* const&, std::_Rb_tree<libsidplayfp::sidemu*, libsidplayfp::sidemu*, std::_Identity<libsidplayfp::sidemu*>, std::less<libsidplayfp::sidemu*>, std::allocator<libsidplayfp::sidemu*> >::_Alloc_node> (stl_tree.h:1827)
==3004954==    by 0x707B4C7: std::pair<std::_Rb_tree_iterator<libsidplayfp::sidemu*>, bool> std::_Rb_tree<libsidplayfp::sidemu*, libsidplayfp::sidemu*, std::_Identity<libsidplayfp::sidemu*>, std::less<libsidplayfp::sidemu*>, std::allocator<libsidplayfp::sidemu*> >::_M_insert_unique<libsidplayfp::sidemu* const&>(libsidplayfp::sidemu* const&) (stl_tree.h:2174)
==3004954==    by 0x707B1EE: insert (stl_set.h:514)
==3004954==    by 0x707B1EE: sidbuilder::lock(libsidplayfp::EventScheduler*, SidConfig::sid_model_t, bool) (sidbuilder.cpp:37)
==3004954==    by 0x70779C4: libsidplayfp::Player::sidCreate(sidbuilder*, SidConfig::sid_model_t, bool, bool, std::vector<unsigned int, std::allocator<unsigned int> > const&) (player.cpp:548)
==3004954==    by 0x7078325: libsidplayfp::Player::config(SidConfig const&, bool) (player.cpp:347)
==3004954==    by 0x70786A4: libsidplayfp::Player::load(SidTune*) (player.cpp:189)
==3004954==    by 0x7083ABC: libsidplayfp::ConsolePlayer::open() (libsidplayfp-api.cpp:486)
==3004954==    by 0x7053637: sidOpenPlayer(ocpfilehandle_t*, cpifaceSessionAPI_t*) (sidplay.cpp:960)
==3004954==    by 0x7054CF6: sidOpenFile(cpifaceSessionAPI_t*, moduleinfostruct*, ocpfilehandle_t*) (sidpplay.cpp:387)
==3004954==    by 0x4EEE93B: plmpOpenFile (cpiface.c:2397)
==3004954==    by 0x4F46906: _fsMain (pfsmain.c:309)
==3004954==    by 0x4ED4F57: init_modules (pmain.c:1113)
```

A C++ guru should probably validate the fault and suggested patch.