### PR TITLE
Makefile.am: move OD/XA checks to configure.ac

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -388,8 +388,6 @@ MAINTAINERCLEANFILES = $(BUILT_SOURCES)
 
 .a65.bin:
 	o65file=`echo $@ | sed 's/bin/o65/'`;\
-	[ -n "$(OD)" ] || { echo "od not found"; false; } &&\
-	[ -n "$(XA)" ] || { echo "xa not found"; false; } &&\
 	${XA} -R -G $< -o $$o65file &&\
 	${OD} -v -An -w8 -tx1 $$o65file | sed -re 's/[[:alnum:]]+/0x&,/g' > $@ &&\
 	${RM} $$o65file

--- a/configure.ac
+++ b/configure.ac
@@ -88,12 +88,14 @@ AC_CHECK_DECL(
 )
 
 AC_CHECK_PROGS([XA], [xa])
+AS_IF([test -z "$XA"], [AC_MSG_ERROR([xa not found])])
 
 # od on macOS doesn't support the -w parameter
 AC_CACHE_CHECK([for od that supports -w], [ac_cv_path_OD],
   [AC_PATH_PROGS_FEATURE_CHECK([OD], [od god],
     [[$ac_path_OD -w > /dev/null 2>&1 && ac_cv_path_OD=$ac_path_OD ac_path_OD_found=:]])]
 )
+AS_IF([test -z "$ac_cv_path_OD"], [AC_MSG_ERROR([od not found])])
 AC_SUBST([OD], [$ac_cv_path_OD])
 
 AX_PTHREAD([], [AC_MSG_ERROR("pthreads not found")])


### PR DESCRIPTION
Abort the configure script (i.e. fail early) if one of these programs are not available.