### PR TITLE
residfp, sidlite: add missing `override` keywords

### DIFF
--- a/src/builders/residfp-builder/residfp.h
+++ b/src/builders/residfp-builder/residfp.h
@@ -35,14 +35,14 @@ protected:
     /**
      * Create the sid emu.
      */
-    libsidplayfp::sidemu* create();
+    libsidplayfp::sidemu* create() override;
 
 public:
     ReSIDfpBuilder(const char * const name);
-    ~ReSIDfpBuilder();
+    ~ReSIDfpBuilder() override;
 
 
-    const char *getCredits() const;
+    const char *getCredits() const override;
 
     /// @name global settings
     /// Settings that affect all SIDs.

--- a/src/builders/sidlite-builder/sidlite.h
+++ b/src/builders/sidlite-builder/sidlite.h
@@ -35,14 +35,14 @@ protected:
     /**
      * Create the sid emu.
      */
-    libsidplayfp::sidemu* create();
+    libsidplayfp::sidemu* create() override;
 
 public:
     SIDLiteBuilder(const char * const name);
     ~SIDLiteBuilder();
 
 
-    const char *getCredits() const;
+    const char *getCredits() const override;
 
 private:
     struct config;


### PR DESCRIPTION
Fixes `-Wsuggest-override` compiler warnings.